### PR TITLE
Fix bug where derivatives are never reused

### DIFF
--- a/Code/Loss.py
+++ b/Code/Loss.py
@@ -144,7 +144,7 @@ def Coll_Loss(
 
         # Check if we can compute D_j from any of the derivatives of U that
         # we've already computed.
-        for i in range(j, 0):
+        for i in reversed(range(0, j)):
             # Get the ith derivative.
             D_i : Derivative = Derivatives[i];
 


### PR DESCRIPTION
In the current code, the derivatives are never reused since range(0,j) always returns an empty list.